### PR TITLE
docs: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,11 @@ const pgOptions = {
 }
 
 const registerCasbin = async () => {
-  try {
-    await fastify.register(require('fastify-casbin'), {
-      model: 'basic_model.conf', // the model configuration
-      adapter: await newAdapter(pgOptions), // the adapter
-      watcher: await newWatcher(pgOptions) // the watcher
-    })
-  } catch (err) {
-    fastify.log.error(err)
-    process.exit(1)
-  }
+  await fastify.register(require('fastify-casbin'), {
+    model: 'basic_model.conf', // the model configuration
+    adapter: await newAdapter(pgOptions), // the adapter
+    watcher: await newWatcher(pgOptions) // the watcher
+  })
 }
 registerCasbin().then(() => {
   // Run the server after async registration

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const { newAdapter } = require('casbin-pg-adapter').default
 const { newWatcher } = require('casbin-pg-watcher')
 
 const pgOptions = {
-  connectionString: 'postgres://localhost'
+  connectionString: 'postgres://localhost',
   migrate: true
 }
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ const fastify = require('fastify')()
 const { newAdapter } = require('casbin-pg-adapter').default
 const { newWatcher } = require('casbin-pg-watcher')
 
-
 const pgOptions = {
   connectionString: 'postgres://localhost',
   migrate: true

--- a/README.md
+++ b/README.md
@@ -59,15 +59,10 @@ const pgOptions = {
   migrate: true
 }
 
-const registerCasbin = async () => {
-  await fastify.register(require('fastify-casbin'), {
-    model: 'basic_model.conf', // the model configuration
-    adapter: await newAdapter(pgOptions), // the adapter
-    watcher: await newWatcher(pgOptions) // the watcher
-  })
-}
-registerCasbin().then(() => {
-  // Run the server after async registration
+fastify.register(require('fastify-casbin'), {
+  model: 'basic_model.conf', // the model configuration
+  adapter: await newAdapter(pgOptions), // the adapter
+  watcher: await newWatcher(pgOptions) // the watcher
 })
 
 // add some policies at application startup

--- a/README.md
+++ b/README.md
@@ -59,24 +59,26 @@ const pgOptions = {
   migrate: true
 }
 
-fastify.register(require('fastify-casbin'), {
-  model: 'basic_model.conf', // the model configuration
-  adapter: await newAdapter(pgOptions), // the adapter
-  watcher: await newWatcher(pgOptions) // the watcher
-})
+async () => {
+  fastify.register(require('fastify-casbin'), {
+    model: 'basic_model.conf', // the model configuration
+    adapter: await newAdapter(pgOptions), // the adapter
+    watcher: await newWatcher(pgOptions) // the watcher
+  })
 
-// add some policies at application startup
-fastify.addHook('onReady', async function () {
-  await fastify.casbin.addPolicy('alice', 'data1', 'read')
-})
+  // add some policies at application startup
+  fastify.addHook('onReady', async function () {
+    await fastify.casbin.addPolicy('alice', 'data1', 'read')
+  })
 
-fastify.get('/protected', async () => {
-  if (!(await fastify.casbin.enforce('alice', 'data1', 'read'))) {
-    throw new Error('Forbidden')
-  }
+  fastify.get('/protected', async () => {
+    if (!(await fastify.casbin.enforce('alice', 'data1', 'read'))) {
+      throw new Error('Forbidden')
+    }
 
-  return `You're in!`
-})
+    return `You're in!`
+  })
+}
 ```
 
 ### Using programmatically assembled model

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ registerCasbin().then(() => {
   // Run the server after async registration
 })
 
-
 // add some policies at application startup
 fastify.addHook('onReady', async function () {
   await fastify.casbin.addPolicy('alice', 'data1', 'read')

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ fastify.get('/protected', async () => {
 import fastify from 'fastify'
 import { join } from 'path'
 import { Model, FileAdapter } from 'casbin'
-import plugin from 'fastify-casbin'
+import fastifyCasbin from 'fastify-casbin'
 
 const modelPath = join(__dirname, 'auth', 'basic_model.conf')
 const policyPath = join(__dirname, 'auth', 'basic_policy.csv')
@@ -96,7 +96,7 @@ const preloadedModel = new Model()
 preloadedModel.loadModel(modelPath)
 const preloadedAdapter = new FileAdapter(policyPath)
 
-app.register(plugin, {
+app.register(fastifyCasbin, {
   model: preloadedModel,
   adapter: preloadedAdapter
 })


### PR DESCRIPTION
The Postgres adapter and watcher example in the README is broken:

Missing a comma after connectionString's value
const pgOptions = {
  connectionString: 'postgres://localhost',
  migrate: true
}
Both await newAdapter... and await newWatcher... will throw a SyntaxError: Unexpected identifier